### PR TITLE
fix(asana,github,cli): resolve issues #6, #7, #8

### DIFF
--- a/src/asana/list-tasks/client.ts
+++ b/src/asana/list-tasks/client.ts
@@ -116,7 +116,8 @@ export function getAsanaClient(config: AsanaConfig): AsanaClientWrapper {
         return { data: result.data || [] };
       },
       addTaskForSection: async (sectionGid: string, body: { data: Record<string, unknown> }) => {
-        const result = await sectionsApi.addTaskForSection(body, sectionGid);
+        // Asana v3 SDK: addTaskForSection(section_gid, opts) where opts = { body: { data: {...} } }
+        const result = await sectionsApi.addTaskForSection(sectionGid, { body });
         return { data: result.data };
       },
     },
@@ -220,7 +221,8 @@ export function createClient(token: string): AsanaClientWrapper {
         return { data: result.data || [] };
       },
       addTaskForSection: async (sectionGid: string, body: { data: Record<string, unknown> }) => {
-        const result = await localSectionsApi.addTaskForSection(body, sectionGid);
+        // Asana v3 SDK: addTaskForSection(section_gid, opts) where opts = { body: { data: {...} } }
+        const result = await localSectionsApi.addTaskForSection(sectionGid, { body });
         return { data: result.data };
       },
     },

--- a/src/common/config-loader/schema.ts
+++ b/src/common/config-loader/schema.ts
@@ -6,6 +6,16 @@
 import { z } from 'zod';
 
 /**
+ * GitHub labels configuration schema
+ */
+export const GitHubLabelsSchema = z.object({
+  autoFix: z.string().optional().describe('Label for auto-fix issues'),
+  skip: z.string().optional().describe('Label to skip auto-fix'),
+  failed: z.string().optional().describe('Label for failed auto-fix'),
+  processing: z.string().optional().describe('Label for in-progress auto-fix'),
+}).optional();
+
+/**
  * GitHub configuration schema
  */
 export const GitHubConfigSchema = z.object({
@@ -16,6 +26,7 @@ export const GitHubConfigSchema = z.object({
   defaultBranch: z.string().optional(),
   autoFixLabel: z.string().optional(),
   skipLabel: z.string().optional(),
+  labels: GitHubLabelsSchema,
 });
 
 /**

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -4,6 +4,20 @@
  */
 
 /**
+ * GitHub 라벨 설정
+ */
+export interface GitHubLabelsConfig {
+  /** auto-fix 대상 라벨 */
+  readonly autoFix?: string;
+  /** auto-fix 제외 라벨 */
+  readonly skip?: string;
+  /** auto-fix 실패 라벨 */
+  readonly failed?: string;
+  /** auto-fix 처리 중 라벨 */
+  readonly processing?: string;
+}
+
+/**
  * GitHub 설정
  */
 export interface GitHubConfig {
@@ -17,10 +31,12 @@ export interface GitHubConfig {
   readonly apiBaseUrl?: string;
   /** 기본 브랜치 (기본값: main) */
   readonly defaultBranch?: string;
-  /** auto-fix 대상 라벨 (기본값: auto-fix) */
+  /** auto-fix 대상 라벨 (기본값: auto-fix) - deprecated, use labels.autoFix */
   readonly autoFixLabel?: string;
-  /** auto-fix 제외 라벨 (기본값: auto-fix-skip) */
+  /** auto-fix 제외 라벨 (기본값: auto-fix-skip) - deprecated, use labels.skip */
   readonly skipLabel?: string;
+  /** 라벨 설정 */
+  readonly labels?: GitHubLabelsConfig;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Issue #6**: Fix Asana v3 SDK `addTaskForSection` API call order causing "Bad Request" errors on section move
- **Issue #7**: Add CLI mode detection to show help instead of hanging when run directly in terminal
- **Issue #8**: Add source-based labels and auto-fix workflow label support from config

## Changes

### Issue #6: Asana Section Move Fix
- Corrected `addTaskForSection` call order in `src/asana/list-tasks/client.ts`
- Asana v3 SDK expects `(sectionGid, { body })` format

### Issue #7: CLI Mode Implementation
- Added `isInteractiveCLI()` function to detect TTY mode
- Added `showHelp()` with usage, commands, MCP tools list
- Added `help`, `--help`, `-h`, `--version`, `-v` commands
- Terminal direct execution now shows help instead of hanging

### Issue #8: GitHub Issue Labels
- Added `source` parameter (asana/sentry/manual) for automatic `source:*` labels
- Added `useAutoFixLabels` parameter to apply workflow labels from config
- Added `GitHubLabelsConfig` interface and Zod schema
- Connected config loader to pass label settings to create-issue tool

## Test plan
- [x] Build passes (`npm run build`)
- [x] Tests pass (`npm test`)
- [x] CLI help command works (`node dist/index.js help`)
- [ ] Manual test: Asana section move
- [ ] Manual test: GitHub issue creation with labels

Closes #6, Closes #7, Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)